### PR TITLE
spec: Update URLs and a dep so we can build in CBS

### DIFF
--- a/python-cicoclient.spec
+++ b/python-cicoclient.spec
@@ -4,7 +4,7 @@ Release:          1
 Summary:          Client interfaces to admin.ci.centos.org
 
 License:          ASL 2.0
-URL:              http://github.com/dmsimard/%{name}
+URL:              http://github.com/CentOS/%{name}
 Source0:          http://pypi.python.org/packages/source/p/%{name}/%{name}-%{version}.tar.gz
 
 BuildArch:        noarch

--- a/python-cicoclient.spec
+++ b/python-cicoclient.spec
@@ -1,6 +1,6 @@
 Name:             python-cicoclient
 Version:          0.3.9
-Release:          1
+Release:          1%{?dist}
 Summary:          Client interfaces to admin.ci.centos.org
 
 License:          ASL 2.0

--- a/python-cicoclient.spec
+++ b/python-cicoclient.spec
@@ -1,6 +1,6 @@
 Name:             python-cicoclient
 Version:          0.3.9
-Release:          dev
+Release:          1
 Summary:          Client interfaces to admin.ci.centos.org
 
 License:          ASL 2.0
@@ -17,6 +17,9 @@ BuildRequires:    python-requests
 BuildRequires:    python-setuptools
 BuildRequires:    python-simplejson
 BuildRequires:    python-six
+
+# Work around an old version of python-sphinx_rtd_theme in CBS
+BuildRequires:    fontawesome-fonts-web
 
 Requires:         python-cliff >= 1.14.0
 Requires:         python-pbr >= 1.6
@@ -78,3 +81,6 @@ rm -rf html/.doctrees html/.buildinfo
 %doc html
 
 %changelog
+* Tue Aug 23 2016 brian@bstinson.com 0.3.9-1
+- Build in the CentOS infrastructure tags
+


### PR DESCRIPTION
Updated a couple of the URLs in the specfile to point to the new repo location,
and put in a temporary BuildRequire until we can coordinate an update of
fontawesome-fonts in CBS.

I didn't change the url pointing to the tarball in PyPi since @dmsimard controls that.