### PR TITLE
Add multiarch support

### DIFF
--- a/cicoclient/ansible/cico.py
+++ b/cicoclient/ansible/cico.py
@@ -40,7 +40,7 @@ options:
     flavor:
         description:
             - The flavor (size) of an altarch Node
-        choices: [tiny, small, medium, lram.tiny, lram.small, lram.medium, xram.tiny, xram.small, xram.medium]
+        choices: [tiny, small, medium, lram.tiny, lram.small, lram.medium, xram.tiny, xram.small, xram.medium, xram.large]
         default: small
 
     count:

--- a/cicoclient/ansible/cico.py
+++ b/cicoclient/ansible/cico.py
@@ -30,13 +30,19 @@ options:
     arch:
         description:
             - Server architecture
-        choices: [i386, x86_64]
+        choices: [i386, x86_64, aarch64, ppc64le]
         default: x86_64
     release:
         description:
             - CentOS release
         choices: [5, 6, 7]
         default: 7
+    flavor:
+        description:
+            - The flavor (size) of an altarch Node
+        choices: [tiny, small, medium, lram.tiny, lram.small, lram.medium, xram.tiny, xram.small, xram.medium]
+        default: small
+
     count:
         description:
             - Amount of nodes
@@ -130,7 +136,7 @@ except ImportError:
 def main():
     argument_spec = dict(
         action=dict(required=True, choices=['get', 'done', 'list']),
-        arch=dict(default='x86_64', choices=['i386', 'x86_64']),
+        arch=dict(default='x86_64', choices=['i386', 'x86_64', 'aarch64', 'ppc64le']),
         release=dict(default='7', choices=['5', '6', '7']),
         count=dict(default=1, type='int'),
         retry_count=dict(default=1, type='int'),
@@ -153,6 +159,7 @@ def main():
     endpoint = module.params['endpoint']
     api_key = module.params['api_key']
     ssid = module.params['ssid']
+    flavor = module.params['flavor']
 
     # Pre-flight validation
     if api_key is None:
@@ -170,7 +177,8 @@ def main():
         if action == 'get':
             hosts, new_ssid = api.node_get(arch=arch, ver=release, count=count,
                                            retry_count=retry_count,
-                                           retry_interval=retry_interval)
+                                           retry_interval=retry_interval,
+                                           flavor=flavor)
             data = {
                 'message': 'Requested servers successfully',
                 'hosts': hosts,

--- a/cicoclient/ansible/cico.py
+++ b/cicoclient/ansible/cico.py
@@ -137,6 +137,10 @@ def main():
     argument_spec = dict(
         action=dict(required=True, choices=['get', 'done', 'list']),
         arch=dict(default='x86_64', choices=['i386', 'x86_64', 'aarch64', 'ppc64le']),
+        flavor=dict(default='small', choices=['tiny', 'small', 'medium',
+                                              'lram.tiny', 'lram.small',
+                                              'xram.tiny', 'xram.small',
+                                              'xram.medium', 'xram.large']),
         release=dict(default='7', choices=['5', '6', '7']),
         count=dict(default=1, type='int'),
         retry_count=dict(default=1, type='int'),

--- a/cicoclient/cli.py
+++ b/cicoclient/cli.py
@@ -54,7 +54,8 @@ class Inventory(Lister):
 
         columns = ('host_id', 'hostname', 'ip_address', 'chassis',
                    'used_count', 'current_state', 'comment', 'distro',
-                   'rel', 'centos_version', 'architecture', 'node_pool')
+                   'rel', 'centos_version', 'architecture', 'node_pool',
+                   'console_port', 'flavor')
 
         return (columns,
                 (utils.get_dict_properties(inventory[host], columns)
@@ -103,6 +104,15 @@ class NodeGet(Lister):
             default=10,
             help='Wait between subsequent retries. Defaults to 10 (seconds).'
         )
+        parser.add_argument(
+            '--flavor',
+            metavar='<flavor>',
+            default=None,
+            choices=['tiny', 'small', 'medium', 'lram.tiny', 'lram.small',
+                     'lram.medium', 'xram.tiny', 'xram.small',
+                     'xram.medium'],
+            help='The flavor of the node.'
+        )
         return parser
 
     @utils.log_method(log)
@@ -116,11 +126,13 @@ class NodeGet(Lister):
                                    ver=parsed_args.release,
                                    count=parsed_args.count,
                                    retry_count=parsed_args.retry_count,
-                                   retry_interval=parsed_args.retry_interval)
+                                   retry_interval=parsed_args.retry_interval,
+                                   flavor=parsed_args.flavor)
 
         columns = ('host_id', 'hostname', 'ip_address', 'chassis',
                    'used_count', 'current_state', 'comment', 'distro',
-                   'rel', 'centos_version', 'architecture', 'node_pool')
+                   'rel', 'centos_version', 'architecture', 'node_pool',
+                   'flavor')
 
         return (columns,
                 (utils.get_dict_properties(hosts[host], columns)
@@ -152,7 +164,8 @@ class NodeDone(Lister):
 
         columns = ('host_id', 'hostname', 'ip_address', 'chassis',
                    'used_count', 'current_state', 'comment', 'distro',
-                   'rel', 'centos_version', 'architecture', 'node_pool')
+                   'rel', 'centos_version', 'architecture', 'node_pool',
+                   'flavor')
 
         return (columns,
                 (utils.get_dict_properties(hosts[host], columns)

--- a/cicoclient/cli.py
+++ b/cicoclient/cli.py
@@ -132,7 +132,7 @@ class NodeGet(Lister):
         columns = ('host_id', 'hostname', 'ip_address', 'chassis',
                    'used_count', 'current_state', 'comment', 'distro',
                    'rel', 'centos_version', 'architecture', 'node_pool',
-                   'flavor')
+                   'console_port', 'flavor')
 
         return (columns,
                 (utils.get_dict_properties(hosts[host], columns)
@@ -165,7 +165,7 @@ class NodeDone(Lister):
         columns = ('host_id', 'hostname', 'ip_address', 'chassis',
                    'used_count', 'current_state', 'comment', 'distro',
                    'rel', 'centos_version', 'architecture', 'node_pool',
-                   'flavor')
+                   'console_port', 'flavor')
 
         return (columns,
                 (utils.get_dict_properties(hosts[host], columns)

--- a/cicoclient/cli.py
+++ b/cicoclient/cli.py
@@ -71,7 +71,7 @@ class NodeGet(Lister):
         parser.add_argument(
             '--arch',
             metavar='<arch>',
-            choices=['i386', 'x86_64'],
+            choices=['i386', 'x86_64', 'aarch64', 'ppc64le'],
             default='x86_64',
             help='Requested server architecture. Defaults to x86_64.'
         )

--- a/cicoclient/cli.py
+++ b/cicoclient/cli.py
@@ -110,7 +110,7 @@ class NodeGet(Lister):
             default=None,
             choices=['tiny', 'small', 'medium', 'lram.tiny', 'lram.small',
                      'lram.medium', 'xram.tiny', 'xram.small',
-                     'xram.medium'],
+                     'xram.medium', 'xram.large'],
             help='The flavor of the node.'
         )
         return parser

--- a/cicoclient/wrapper.py
+++ b/cicoclient/wrapper.py
@@ -50,7 +50,8 @@ class CicoWrapper(client.CicoClient):
 
         keys = ['host_id', 'hostname', 'ip_address', 'chassis',
                 'used_count', 'current_state', 'comment', 'distro',
-                'rel', 'centos_version', 'architecture', 'node_pool']
+                'rel', 'centos_version', 'architecture', 'node_pool',
+                'console_port', 'flavor']
 
         real_inventory = dict()
         for host in inventory:
@@ -114,14 +115,15 @@ class CicoWrapper(client.CicoClient):
             else:
                 return self.self_inventory
 
-    def node_get(self, arch=None, ver=None, count=1, retry_count=1,
-                 retry_interval=10):
+    def node_get(self, arch=None, ver=None, flavor=None, count=1,
+                 retry_count=1, retry_interval=10):
         """
         Requests specified amount of nodes with the provided parameters.
 
         :param arch: Server architecture (ex: x86_64)
         :param ver: CentOS version (ex: 7)
         :param count: Amount of servers (ex: 2)
+        :parma flavor: The flavor of machine to use (multi-arch only)
         :param retry_count: Number of times to retry in case of failure (ex: 5)
         :param retry_interval: Wait in seconds between each retry (ex: 30)
         :return: [ [ requested_hosts ], ssid ]
@@ -134,6 +136,8 @@ class CicoWrapper(client.CicoClient):
             args += "&arch=%s" % arch
         if ver is not None:
             args += "&ver=%s" % ver
+        if flavor is not None:
+            args += "&flavor=%s" % flavor
         args += "&count=%s" % count
 
         resp, body = self.get('Node/get?%s' % args)

--- a/docs/ansible_usage.rst
+++ b/docs/ansible_usage.rst
@@ -44,7 +44,7 @@ use ``ansible-doc`` to access it::
 
     - flavor
         The flavor (size) of an altarch Node
-        (Choices: tiny, small, medium, lram.tiny, lram.small, lram.medium, xram.tiny, xram.small, xram.medium)[Default: small]
+        (Choices: tiny, small, medium, lram.tiny, lram.small, lram.medium, xram.tiny, xram.small, xram.medium, xram.large)[Default: small]
 
     - retry_count
             Amount of retries to do in case of failure. [Default: 1]

--- a/docs/ansible_usage.rst
+++ b/docs/ansible_usage.rst
@@ -31,7 +31,7 @@ use ``ansible-doc`` to access it::
             API key [Default: CICO_API_KEY environment variable or None]
 
     - arch
-            Server architecture (Choices: i386, x86_64) [Default: x86_64]
+            Server architecture (Choices: i386, x86_64, aarch64, ppc64le) [Default: x86_64]
 
     - count
             Amount of nodes [Default: 1]
@@ -41,6 +41,10 @@ use ``ansible-doc`` to access it::
 
     - release
             CentOS release (Choices: 5, 6, 7) [Default: 7]
+
+    - flavor
+        The flavor (size) of an altarch Node
+        (Choices: tiny, small, medium, lram.tiny, lram.small, lram.medium, xram.tiny, xram.small, xram.medium)[Default: small]
 
     - retry_count
             Amount of retries to do in case of failure. [Default: 1]

--- a/docs/ansible_usage.rst
+++ b/docs/ansible_usage.rst
@@ -43,7 +43,7 @@ use ``ansible-doc`` to access it::
             CentOS release (Choices: 5, 6, 7) [Default: 7]
 
     - flavor
-        The flavor (size) of an altarch Node
+        The flavor (size) of an altarch Node (ignored on baremetal x86_64)
         (Choices: tiny, small, medium, lram.tiny, lram.small, lram.medium, xram.tiny, xram.small, xram.medium, xram.large)[Default: small]
 
     - retry_count

--- a/docs/cli_usage.rst
+++ b/docs/cli_usage.rst
@@ -156,7 +156,7 @@ Built-in help::
           --retry-interval <seconds>
                                 Wait between subsequent retries. Defaults to 10
                                 (seconds).
-          --flavor <flavor>     The flavor of the node.
+          --flavor <flavor>     The flavor of the node. (This is ignored for x86_64 baremetal nodes)
 
         output formatters:
           output formatter options

--- a/docs/cli_usage.rst
+++ b/docs/cli_usage.rst
@@ -110,22 +110,22 @@ Usage::
         $ cico inventory
         Starting new HTTP connection (1): admin.ci.centos.org
         Resetting dropped connection: admin.ci.centos.org
-        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+
-        | host_id |   hostname    | ip_address   |  chassis  | used_count | current_state | comment                              | distro | rel  | centos_version | architecture | node_pool |
-        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+
-        |     170 | node1.cluster | <obfuscated> | <cluster> |         66 | Deployed      | e0c382aa-8a30-11e5-b2e3-525400ea212d | None   | None | 7              | x86_64       |         0 |
-        |      21 | node2.cluster | <obfuscated> | <cluster> |         66 | Deployed      | b54cea7a-8a40-11e5-b2e3-525400ea212d | None   | None | 7              | x86_64       |         0 |
-        |      64 | node3.cluster | <obfuscated> | <cluster> |         67 | Deployed      | 3b413756-8967-11e5-b2e3-525400ea212d | None   | None | 7              | x86_64       |         0 |
-        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+
+        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+--------------+-------------+
+        | host_id |   hostname    | ip_address   |  chassis  | used_count | current_state | comment                              | distro | rel  | centos_version | architecture | node_pool | console_port | flavor      |
+        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+--------------+-------------+
+        |     170 | node1.cluster | <obfuscated> | <cluster> |         66 | Deployed      | e0c382aa                             | None   | None | 7              | x86_64       |         0 | 1234         | small       |
+        |      21 | node2.cluster | <obfuscated> | <cluster> |         66 | Deployed      | b54cea7a                             | None   | None | 7              | x86_64       |         0 | 5678         | medium      |
+        |      64 | node3.cluster | <obfuscated> | <cluster> |         67 | Deployed      | 3b413756                             | None   | None | 7              | x86_64       |         0 | 2349         | tiny        |
+        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+--------------+-------------+
 
         $ cico inventory --ssid b54cea7a-8a40-11e5-b2e3-525400ea212d
         Starting new HTTP connection (1): admin.ci.centos.org
         Resetting dropped connection: admin.ci.centos.org
-        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+
-        | host_id |   hostname    | ip_address   |  chassis  | used_count | current_state | comment                              | distro | rel  | centos_version | architecture | node_pool |
-        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+
-        |      21 | node2.cluster | <obfuscated> | <cluster> |         66 | Deployed      | b54cea7a-8a40-11e5-b2e3-525400ea212d | None   | None | 7              | x86_64       |         0 |
-        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+
+        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+--------------+-------------+
+        | host_id |   hostname    | ip_address   |  chassis  | used_count | current_state | comment                              | distro | rel  | centos_version | architecture | node_pool | console_port | flavor      |
+        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+--------------+-------------+
+        |      21 | node2.cluster | <obfuscated> | <cluster> |         66 | Deployed      | b54cea7a                             | None   | None | 7              | x86_64       |         0 | 5678         | medium      |
+        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+--------------+-------------+
 
 
 Requesting nodes
@@ -137,10 +137,11 @@ Built-in help::
 
         $ cico help node get
         usage: cico node get [-h] [-f {csv,json,table,value,yaml}] [-c COLUMN]
-                             [--max-width <integer>] [--noindent]
-                             [--quote {all,minimal,none,nonnumeric}] [--arch <arch>]
-                             [--release <release>] [--count <count>]
-                             [--retry-count <count>] [--retry-interval <seconds>]
+                     [--max-width <integer>] [--fit-width] [--print-empty]
+                     [--noindent] [--quote {all,minimal,none,nonnumeric}]
+                     [--arch <arch>] [--release <release>] [--count <count>]
+                     [--retry-count <count>] [--retry-interval <seconds>]
+                     [--flavor <flavor>]
 
         Requests nodes from the ci.centos.org infrastructure
 
@@ -155,6 +156,7 @@ Built-in help::
           --retry-interval <seconds>
                                 Wait between subsequent retries. Defaults to 10
                                 (seconds).
+          --flavor <flavor>     The flavor of the node.
 
         output formatters:
           output formatter options
@@ -181,12 +183,12 @@ Usage::
         Starting new HTTP connection (1): admin.ci.centos.org
         Resetting dropped connection: admin.ci.centos.org
         Resetting dropped connection: admin.ci.centos.org
-        SSID for these servers: 8fd381ea-8a46-11e5-b2e3-525400ea212d
-        +---------+----------------+--------------+---------+------------+---------------+---------+--------+------+----------------+--------------+-----------+
-        | host_id |    hostname    |  ip_address  | chassis | used_count | current_state | comment | distro | rel  | centos_version | architecture | node_pool |
-        +---------+----------------+--------------+---------+------------+---------------+---------+--------+------+----------------+--------------+-----------+
-        |     117 | node4.cluster  | <obfuscated> | cluster |         69 | Ready         | -       | None   | None | 7              | x86_64       |         1 |
-        +---------+----------------+--------------+---------+------------+---------------+---------+--------+------+----------------+--------------+-----------+
+        SSID for these servers: 8fd381ea
+        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+--------------+-------------+
+        | host_id |   hostname    | ip_address   |  chassis  | used_count | current_state | comment                              | distro | rel  | centos_version | architecture | node_pool | console_port | flavor      |
+        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+--------------+-------------+
+        |     117 | node4.cluster | <obfuscated> | <cluster> |         69 | Ready         | -                                    | None   | None | 7              | x86_64       |         1 | 5678         | medium      |
+        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+--------------+-------------+
 
 Releasing nodes
 ~~~~~~~~~~~~~~~
@@ -237,11 +239,11 @@ Usage::
         Resetting dropped connection: admin.ci.centos.org
         Resetting dropped connection: admin.ci.centos.org
         Released these servers with SSID: 8fd381ea-8a46-11e5-b2e3-525400ea212d
-        +---------+---------------+--------------+---------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+
-        | host_id |    hostname   |  ip_address  | chassis | used_count | current_state | comment                              | distro | rel  | centos_version | architecture | node_pool |
-        +---------+---------------+--------------+---------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+
-        |     117 | node4.cluster | <obfuscated> | cluster |         69 | Deployed      | 8fd381ea-8a46-11e5-b2e3-525400ea212d | None   | None | 7              | x86_64       |         1 |
-        +---------+---------------+--------------+---------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+
+        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+--------------+-------------+
+        | host_id |   hostname    | ip_address   |  chassis  | used_count | current_state | comment                              | distro | rel  | centos_version | architecture | node_pool | console_port | flavor      |
+        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+--------------+-------------+
+        |     117 | node4.cluster | <obfuscated> | <cluster> |         69 | Deployed      | 8fd381ea                             | None   | None | 7              | x86_64       |         1 | 5678         | medium      |
+        +---------+---------------+--------------+-----------+------------+---------------+--------------------------------------+--------+------+----------------+--------------+-----------+--------------+-------------+
 
 .. _Duffy documentation: https://wiki.centos.org/QaWiki/CI/Duffy
 .. _cliff: https://pypi.python.org/pypi/cliff


### PR DESCRIPTION
This PR should be coordinated with an upcoming release of Duffy, do not merge yet! The unreleased duffy version is available on the dev instance for testing purposes.

We are bootstrapping multiarch support in ci.centos.org by doing libvirt VMs on our hardware. These VMs are sized based on the 'flavors' we use in cico cloud. 

The goal is to add support for the flavor selector, and add the appropriate entries to the various inventories that are returned to the user.

Rolled up in this as well: we recently added a column that identifies a TCP port that connects to the serial console for some of our hardware. This feature is not currently in use, but the serial port is in the column list so we should return it in the UI. 