### PR TITLE
Add api_key lookup

### DIFF
--- a/cicoclient/ansible/cico.py
+++ b/cicoclient/ansible/cico.py
@@ -13,6 +13,9 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 #
+
+from ansible.module_utils.basic import AnsibleModule
+
 DOCUMENTATION = '''
 ---
 module: cico
@@ -40,7 +43,17 @@ options:
     flavor:
         description:
             - The flavor (size) of an altarch Node
-        choices: [tiny, small, medium, lram.tiny, lram.small, lram.medium, xram.tiny, xram.small, xram.medium, xram.large]
+        choices:
+        - tiny
+        - small
+        - medium
+        - lram.tiny
+        - lram.small
+        - lram.medium
+        - xram.tiny
+        - xram.small
+        - xram.medium
+        - xram.large
         default: small
 
     count:
@@ -62,7 +75,9 @@ options:
     api_key:
         description:
             - API key
-        default: CICO_API_KEY environment variable, the contents of ~/.duffy.key, the contents of ~/duffy.key, or None
+        default: >
+          CICO_API_KEY environment variable, the contents of ~/.duffy.key,
+          the contents of ~/duffy.key, or None
     ssid:
         description:
             - SessionID, required with action 'done', optional with 'list'.
@@ -125,6 +140,7 @@ EXAMPLES = '''
     api_key: 723ef3ce-4ea4-4e8d-9c8a-20a8249b2955
     ssid: 3e03553f-ae28-4a68-b879-f0fdbf949d5d
 '''
+
 try:
     from cicoclient.wrapper import CicoWrapper
     HAS_CICO = True
@@ -135,7 +151,8 @@ except ImportError:
 def main():
     argument_spec = dict(
         action=dict(required=True, choices=['get', 'done', 'list']),
-        arch=dict(default='x86_64', choices=['i386', 'x86_64', 'aarch64', 'ppc64le']),
+        arch=dict(default='x86_64', choices=['i386', 'x86_64', 'aarch64',
+                                             'ppc64le']),
         flavor=dict(default='small', choices=['tiny', 'small', 'medium',
                                               'lram.tiny', 'lram.small',
                                               'xram.tiny', 'xram.small',
@@ -208,7 +225,6 @@ def main():
     except Exception as e:
         module.fail_json(msg=e.message)
 
-from ansible.module_utils.basic import *  # noqa
 
 if __name__ == '__main__':
     main()

--- a/cicoclient/cli.py
+++ b/cicoclient/cli.py
@@ -14,7 +14,6 @@
 #
 
 import logging
-import sys
 
 from cliff.lister import Lister
 from cicoclient.wrapper import CicoWrapper

--- a/cicoclient/shell.py
+++ b/cicoclient/shell.py
@@ -14,7 +14,6 @@
 #
 
 import sys
-import os
 
 import cicoclient
 from cliff.app import App

--- a/cicoclient/shell.py
+++ b/cicoclient/shell.py
@@ -47,9 +47,11 @@ class CicoCli(App):
         parser.add_argument(
             '--api-key',
             metavar='<api-key>',
-            help='API key to admin.ci.centos.org service. Defaults to'
-                 ' environment variable for CICO_API_KEY.',
-            default=os.getenv('CICO_API_KEY', None)
+            help='API key to admin.ci.centos.org service. If not provided the'
+                 ' value of the CICO_API_KEY environment variable will be used'
+                 ' if defined, followed by the contents of ~/.duffy.key if'
+                 ' present, finally the contents of ~/duffy.key if present.',
+            default=None
         )
 
         return parser


### PR DESCRIPTION
- Add api_key lookup to wrapper.py
  - Use api_key if provided
  - Use value of CICO_API_KEY
  - Use contents of ~/.duffy.key
  - Use contents of ~/duffy.key

- Update ansible module to simply default to None and use lookup from
wrapper

- Update shell.py to default to None and use lookup from wrapper.

Resolves #10 