### PR TITLE
guard for non-dict bodies in node get

### DIFF
--- a/cicoclient/wrapper.py
+++ b/cicoclient/wrapper.py
@@ -167,6 +167,9 @@ class CicoWrapper(client.CicoClient):
 
         if not body:
             raise exceptions.NoInventory
+            
+        if not isinstance(body, dict):
+            raise ValueError(str(body))
 
         # Get the hosts that were requested.
         # Note: We have to iterate over full inventory instead of just the


### PR DESCRIPTION
the API returns a string when there is an error, raise that error to the user

example:

    "Failed to allocate nodes: Rate limit exceeded: 6 sessions in the last 5 minutes"